### PR TITLE
refactor(DiamondCutFacet.sol): use diamondCut from library

### DIFF
--- a/contracts/facets/DiamondCutFacet.sol
+++ b/contracts/facets/DiamondCutFacet.sol
@@ -25,37 +25,6 @@ contract DiamondCutFacet is IDiamondCut {
         bytes calldata _calldata
     ) external override {
         LibDiamond.enforceIsContractOwner();
-        LibDiamond.DiamondStorage storage ds = LibDiamond.diamondStorage();
-        uint256 originalSelectorCount = ds.selectorCount;
-        uint256 selectorCount = originalSelectorCount;
-        bytes32 selectorSlot;
-        // Check if last selector slot is not full
-        // "selectorCount & 7" is a gas efficient modulo by eight "selectorCount % 8" 
-        if (selectorCount & 7 > 0) {
-            // get last selectorSlot
-            // "selectorCount >> 3" is a gas efficient division by 8 "selectorCount / 8"
-            selectorSlot = ds.selectorSlots[selectorCount >> 3];
-        }
-        // loop through diamond cut
-        for (uint256 facetIndex; facetIndex < _diamondCut.length; facetIndex++) {
-            (selectorCount, selectorSlot) = LibDiamond.addReplaceRemoveFacetSelectors(
-                selectorCount,
-                selectorSlot,
-                _diamondCut[facetIndex].facetAddress,
-                _diamondCut[facetIndex].action,
-                _diamondCut[facetIndex].functionSelectors
-            );
-        }
-        if (selectorCount != originalSelectorCount) {
-            ds.selectorCount = uint16(selectorCount);
-        }
-        // If last selector slot is not full
-        // "selectorCount & 7" is a gas efficient modulo by eight "selectorCount % 8" 
-        if (selectorCount & 7 > 0) {
-            // "selectorCount >> 3" is a gas efficient division by 8 "selectorCount / 8"
-            ds.selectorSlots[selectorCount >> 3] = selectorSlot;
-        }
-        emit DiamondCut(_diamondCut, _init, _calldata);
-        LibDiamond.initializeDiamondCut(_init, _calldata);
+        LibDiamond.diamondCut(_diamondCut, _init, _calldata);
     }
 }


### PR DESCRIPTION
#### Motivation
Since this repo, just like the `diamond-1-hardhat` and `diamond-3-hardhat` are for reference implementations, was thinking reusing the `diamondCut` from the `LibDiamond` in the `DiamondCutFacet.sol` would be helpful for new readers to understand how the cut logic differs from the other implementations (instead of duplicating the same pre logic for `addReplaceRemoveFacetSelectors`).

I totally understand that `diamond-2-hardhat` should be the most efficient in terms of diamond cutting. Even so, using the library instead uses more gas (not that significant) 😅. Is this worth doing this to help demonstrate how the cutting logic works?

- [DiamondCutFacet from implementation 1](https://github.com/mudgen/diamond-1-hardhat/blob/main/contracts/facets/DiamondCutFacet.sol)
- [DiamondCutFacet from implementation 2 (current)](https://github.com/mudgen/diamond-2-hardhat/blob/main/contracts/facets/DiamondCutFacet.sol)
- [DiamondCutFacet from implementation 3](https://github.com/mudgen/diamond-3-hardhat/blob/main/contracts/facets/DiamondCutFacet.sol)

#### Gas report for the current repo test
Current:
- `diamondCut` method:  avg gas for 22 calls 348444
-  `DiamondCutFacet` deployment method:  avg gas for 22 calls 1952190

Proposed:
- `diamondCut` method:  avg gas for 22 calls 349019
- `DiamondCutFacet` deployment method:  avg gas for 22 calls 1974592
