### PR TITLE
Allow diamondCut to be extended in a derived facet

### DIFF
--- a/contracts/facets/DiamondCutFacet.sol
+++ b/contracts/facets/DiamondCutFacet.sol
@@ -23,7 +23,7 @@ contract DiamondCutFacet is IDiamondCut {
         FacetCut[] calldata _diamondCut,
         address _init,
         bytes calldata _calldata
-    ) external override {
+    ) public virtual override {
         LibDiamond.enforceIsContractOwner();
         LibDiamond.DiamondStorage storage ds = LibDiamond.diamondStorage();
         uint256 originalSelectorCount = ds.selectorCount;


### PR DESCRIPTION
Adding here the same change that was introduced recently in the [diamond-2](https://github.com/mudgen/diamond-2/pull/12) repo

> This PR updates the visibility of the diamondCut method in DiamondCutFacet from external to public and adds the virtual keyword. This change enables the method to be overridden and extended in a derived facet.

